### PR TITLE
Fix command line arg for stream delay

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ RUN go build -o connect-demo .
 FROM alpine
 RUN apk add --update --no-cache ca-certificates tzdata && rm -rf /var/cache/apk/*
 COPY --from=builder /workspace/connect-demo /usr/local/bin/connect-demo
-CMD [ "/usr/local/bin/connect-demo -server-stream-delay=500ms" ]
+CMD [ "/usr/local/bin/connect-demo --server-stream-delay=500ms" ]


### PR DESCRIPTION
The deployed demo does not seem to be honoring the passed in stream delay.  It seems to be because of the format for the command line arg.  This fixes the syntax.