### PR TITLE
Redirect to the actual demo app

### DIFF
--- a/main.go
+++ b/main.go
@@ -142,7 +142,7 @@ func main() {
 	mux := http.NewServeMux()
 	mux.Handle(
 		"/",
-		http.RedirectHandler("https://connect.build", http.StatusFound),
+		http.RedirectHandler("https://connect.build/demo", http.StatusFound),
 	)
 	compress1KB := connect.WithCompressMinBytes(1024)
 	mux.Handle(elizav1connect.NewElizaServiceHandler(


### PR DESCRIPTION
Now that we actually have a demo app, we should redirect there instead
of the Connect homepage.
