### PR TITLE
Update CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ on:
 env:
   MAKEFLAGS: "-j 8"
   PRIVATE_REGISTRY_HOST: us-central1-docker.pkg.dev
-  PRIVATE_REGISTRY_URL: us-central1-docker.pkg.dev/buf-connect-demo-1/buf-connect-demo-1-connect-demo-registry
+  PRIVATE_REGISTRY_URL: us-central1-docker.pkg.dev/connect-demo-393314/connect-demo-registry
 permissions:
   contents: read
   id-token: 'write'
@@ -30,7 +30,7 @@ jobs:
         run: make test && make checkgenerate
       - name: make-lint
         run: make lint
-  docker-build-push-connect-demo:
+  docker-build-push:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs:
@@ -43,8 +43,8 @@ jobs:
         uses: google-github-actions/auth@v1
         with:
           token_format: 'access_token'
-          workload_identity_provider: projects/739284710670/locations/global/workloadIdentityPools/connect-demo-ar-wif-pool/providers/connect-demo-ar-wif-provider
-          service_account: ar-writer-service-account@buf-connect-demo-1.iam.gserviceaccount.com
+          workload_identity_provider: projects/409526754884/locations/global/workloadIdentityPools/connect-demo-wif-pool/providers/connect-demo-wif-provider
+          service_account: connect-demo-registry-writer@connect-demo-393314.iam.gserviceaccount.com
       - name: login-gcr
         uses: docker/login-action@v2
         with:


### PR DESCRIPTION
This pushes artifacts to a new GCP project and updates the associated cloud run service that hosts the demo at https://demo.connectrpc.com, @rubensf I've already tested this with a private copy already but it's still worth double checking the names of things.

@akshayjshah I'm adding you as a reviewer to confirm that there will be no new updates to demo.connect.build after this is merged.